### PR TITLE
we need the category on posts to be indexed

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -39,7 +39,7 @@ module.exports = function (args, callback) {
     hexo.extend.filter.register('after_post_render', function(data){
         if(data.published){
             data.objectID = computeSha1(data.permalink);
-            posts.push(_.pick(data, ['title', 'slug', 'permalink', 'content', 'lede', 'objectID', 'hero']));
+            posts.push(_.pick(data, ['title', 'slug', 'permalink', 'content', 'lede', 'objectID', 'hero', 'category']));
         }
         return data;
     });


### PR DESCRIPTION
currently algolia doesnt index the 'category' of a post. We want this so it's easier to search blog posts per category via the API

once this is merged we need to run an `npm install` on the blog and push it
